### PR TITLE
Add lessjs task

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,1 @@
+BOOT_VERSION=2.7.2

--- a/build.boot
+++ b/build.boot
@@ -1,0 +1,35 @@
+(set-env! :dependencies  '[[org.clojure/clojure "1.8.0" :scope "provided"]
+                           [degree9/boot-npm    "1.7.0-SNAPSHOT"]
+                           [degree9/boot-exec   "1.1.0-SNAPSHOT"]
+                           [adzerk/bootlaces    "0.1.13" :scope "test"]
+                           [degree9/boot-semver "1.6.0" :scope "test"]]
+          :resource-paths   #{"src"})
+
+(require '[degree9.boot-semver :refer :all])
+
+(task-options!
+ pom    {:project 'degree9/boot-css
+         :description "CSS Preprocessors for boot-clj."
+         :url         "https://github.com/degree9/boot-exec"
+         :scm         {:url "https://github.com/degree9/boot-exec"}})
+
+(deftask develop
+  "Build boot-css for development."
+  []
+  (comp
+   (version :develop true
+            :minor 'inc
+            :patch 'zero
+            :pre-release 'snapshot)
+   (watch)
+   (target)
+   (build-jar)))
+
+(deftask deploy
+  "Build boot-css and deploy to clojars."
+  []
+  (comp
+   (version)
+   (target)
+   (build-jar)
+   (push-release)))

--- a/src/degree9/boot_css.clj
+++ b/src/degree9/boot_css.clj
@@ -1,0 +1,56 @@
+(ns degree9.boot-css
+  (:require [boot.core :as boot]
+            [clojure.string :as str]
+            [clojure.java.io :as io]
+            [boot.util :as u]
+            [degree9.boot-npm :as npm]))
+
+(defn compile-less-file!
+  [fs tmp-dir tmp-file & [{:keys [include-dirs]}]]
+  (let [compiled-file (io/file tmp-dir (str/replace (boot/tmp-path tmp-file) #"\.less$" ".css"))
+        ]
+    (u/dbug* "Less boot dir: %s\n" (boot/tmp-dir tmp-file))
+    (u/dbug* "Less boot file: %s\n" (-> tmp-file boot/tmp-file .getAbsolutePath))
+    (u/dbug* "Less boot target: %s\n" (.getAbsolutePath compiled-file))
+    ;; boot magic, we trigger the task for side effects targeting the absolute
+    ;; folders only.
+    (((npm/exec :module "less"
+                :process "lessc"
+                :arguments (->> [(when (seq include-dirs)
+                                   (str "--include-path=" include-dirs))
+                                 (-> tmp-file boot/tmp-file .getAbsolutePath)
+                                 (.getAbsolutePath compiled-file)]
+                                (keep identity)
+                                vec))
+      identity) fs)))
+
+(boot/deftask lessc
+  "Compile CSS using the npm version of Less."
+  [l less-file    PATH  str    "Path to the .less file to compile (relative to the fileset)."
+   d less-dir     PATH  str    "Path to a dir containing .less files."
+   i include-dirs PATH  #{str} "Include directories for lessc."]
+  (assert (or less-file less-dir) "Either a less-file or less-dir should be present for this task to work.")
+  (assert (not (and less-file less-dir)) "The less-file and less-dir parameters are mutually exclusive.")
+
+  (let [tmp (boot/tmp-dir!)]
+    (boot/with-pre-wrap [fs]
+      (let [less-dirs (when less-dir
+                        (->> fs
+                             boot/ls
+                             (boot/by-re [(re-pattern (str less-dir ".*\\.less$"))])
+                             seq))
+            less-tmp-files (->> (or less-dirs #{})
+                                (into [(when less-file (boot/tmp-get fs less-file))])
+                                (keep identity)
+                                vec)
+            include-dirs (->> less-tmp-files
+                              (mapv #(boot/tmp-dir %))
+                              (into (or include-dirs #{}))
+                              (str/join ":"))]
+        (u/dbug* "Less TmpFiles: %s\n" less-tmp-files)
+
+        (assert (seq less-tmp-files)
+                (format "Cannot find less files on the classpath, review your parameters (less-file=%s, less-dir=%s)." less-file less-dir))
+        (run! #(compile-less-file! fs tmp % {:include-dirs include-dirs})
+              less-tmp-files)
+        (-> fs (boot/add-resource tmp) boot/commit!)))))

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,2 @@
+#Mon May 01 18:58:18 MDT 2017
+VERSION=1.0.0


### PR DESCRIPTION
This task uses npm in order to install and launch the lessc compiler against
the input .less file. The output will be included into the fileset by default.

At the moment only the --include-dirs option is handled and passed to lessc.